### PR TITLE
Use the user agent also while downloading smh, now Modrinth can actually track it.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Version and packaging info
-version=1.3.0
+version=1.3.1
 maven_group=
 archives_base_name=Complementary-Installer
 

--- a/src/main/java/net/hypercubemc/iris_installer/Downloader.java
+++ b/src/main/java/net/hypercubemc/iris_installer/Downloader.java
@@ -29,6 +29,7 @@ public class Downloader extends SwingWorker<Void, Void> {
         URL url = new URL(this.url);
         HttpsURLConnection connection = (HttpsURLConnection) url
                 .openConnection();
+        connection.setRequestProperty("User-Agent", "Complementary-Installer");
         long filesize = connection.getContentLengthLong();
 
         if (filesize == -1) {


### PR DESCRIPTION
I totally forgot that we also need to set the user agent while downloading the file...
Otherwise, the very new Modrinth source tracking they just added for us... would do _nothing_